### PR TITLE
minor doc update to make the example compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/SlyMarbo/spdy" // Simply import SPDY.
+	_ "github.com/SlyMarbo/spdy" // Simply import SPDY.
 	"io/ioutil"
 )
 


### PR DESCRIPTION
import with the blank identifier, since this import is solely for initialization side-effects
