### PR TITLE
Do not enforce certain fields in client requests

### DIFF
--- a/spdy3_conn.go
+++ b/spdy3_conn.go
@@ -237,7 +237,7 @@ func (conn *connV3) Request(request *http.Request, receiver Receiver, priority P
 	}
 
 	url := request.URL
-	if url == nil || url.Scheme == "" || url.Host == "" || url.Path == "" {
+	if url == nil || url.Path == "" {
 		return nil, errors.New("Error: Incomplete path provided to resource.")
 	}
 


### PR DESCRIPTION
This is something we noticed when doing client requests

   Error: Incomplete path provided to resource."

Researching a bit we saw some of the fields for URL are commonly empty, see http://golang.org/pkg/net/http/#Request 

```
// For most requests, fields other than Path and RawQuery
// will be empty. (See RFC 2616, Section 5.1.2)
```

and we found that this is the case for our requests. Not sure if this is safe, but it seems to be, based on the comments.

There is similar code for Push, though that may be an entirely different can of worms.
