### PR TITLE
Handle v3.1 in transport

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -251,7 +251,8 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 				t.m.Unlock()
 				return t.doHTTP(tcpConn, req)
 
-			case "spdy/3":
+			case "spdy/3": fallthrough
+			case "spdy/3.1":
 				newConn, err := NewClientConn(tlsConn, t.PushReceiver, 3)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Not sure if this is the correct solution. Here's the symptom it addresses:

```
ssl := &tls.Config{
    InsecureSkipVerify: true, // FIXME: check cert
}

client := new(http.Client)
client.Transport = new(spdy.Transport)
client.Transport.(*spdy.Transport).TLSClientConfig = ssl
```

I start the server with ListenAndServeSPDY. When I try to connect, it crashes. 

```
req, err := http.NewRequest("GET", "https://localhost:12345/konea/agent/123", nil)
resp, err := client.Do(req)
```

This logs:

```
   (spdy debug) 2014/03/25 12:04:55 Requesting "https://localhost:12345/konea/agent/123" over SPDY.
```

and then crashes at transport.go:299

```
stream, err := conn.Request(req, res, priority)
```

conn is nil here. 
