### PR TITLE
Adds a ListenAndServeSPDYNoNPN for "implicit SPDY"

### DIFF
--- a/server_conn.go
+++ b/server_conn.go
@@ -530,6 +530,60 @@ func ListenAndServeSPDY(addr string, certFile string, keyFile string, handler ht
 	}
 }
 
+func ListenAndServeSPDYNoNPN(addr string, certFile string, keyFile string, handler http.Handler, version float64) error {
+	if addr == "" {
+		addr = ":https"
+	}
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+	server := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+		TLSConfig: &tls.Config{
+			Certificates: make([]tls.Certificate, 1),
+		},
+	}
+
+	var err error
+	server.TLSConfig.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	tlsListener := tls.NewListener(conn, server.TLSConfig)
+	defer tlsListener.Close()
+
+	// Main loop
+	var tempDelay time.Duration
+	for {
+		rw, e := tlsListener.Accept()
+		if e != nil {
+			if ne, ok := e.(net.Error); ok && ne.Temporary() {
+				if tempDelay == 0 {
+					tempDelay = 5 * time.Millisecond
+				} else {
+					tempDelay *= 2
+				}
+				if max := 1 * time.Second; tempDelay > max {
+					tempDelay = max
+				}
+				log.Printf("Accept error: %v; retrying in %v", e, tempDelay)
+				time.Sleep(tempDelay)
+				continue
+			}
+			return e
+		}
+		tempDelay = 0
+		go serveSPDYNoNPN(rw, server, version)
+	}
+}
+
 func serveSPDY(conn net.Conn, srv *http.Server) {
 	defer func() {
 		if v := recover(); v != nil {
@@ -561,6 +615,43 @@ func serveSPDY(conn net.Conn, srv *http.Server) {
 	if fn := srv.TLSNextProto[proto]; fn != nil {
 		fn(srv, tlsConn, nil)
 	}
+	return
+}
+
+func serveSPDYNoNPN(conn net.Conn, srv *http.Server, version float64) {
+	defer func() {
+		if v := recover(); v != nil {
+			const size = 4096
+			buf := make([]byte, size)
+			buf = buf[:runtime.Stack(buf, false)]
+			log.Printf("panic serving %v: %v\n%s", conn.RemoteAddr(), v, buf)
+		}
+	}()
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok { // Only allow TLS connections.
+		return
+	}
+
+	if d := srv.ReadTimeout; d != 0 {
+		conn.SetReadDeadline(time.Now().Add(d))
+	}
+	if d := srv.WriteTimeout; d != 0 {
+		conn.SetWriteDeadline(time.Now().Add(d))
+	}
+	if err := tlsConn.Handshake(); err != nil {
+		return
+	}
+
+	serverConn, err := NewServerConn(tlsConn, srv, version)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	serverConn.Run()
+	serverConn = nil
+	runtime.GC()
+
 	return
 }
 


### PR DESCRIPTION
This is mainly for clients who do not have NPN in their OpenSSL library, with SPDY set to listen on a dedicated port per SPDY version (443 mapped to HTTPS / NPN, 444 mapped to SPDY/3.1, 445 mapped to SPDY/3.0, etc.). I'm not sure how mainstream of a feature this is, and how maintainable this patch is, so don't hesitate to yell at me.

I'm using this with [CocoaSPDY](https://github.com/twitter/CocoaSPDY), because the iOS OpenSSL libraries don't have NPN support yet.
