### PR TITLE
Fix race condition in spdy3_conn

### DIFF
--- a/spdy3_conn.go
+++ b/spdy3_conn.go
@@ -157,6 +157,8 @@ func (c *connV3) Conn() net.Conn {
 // InitialWindowSize gives the most recently-received value for
 // the INITIAL_WINDOW_SIZE setting.
 func (conn *connV3) InitialWindowSize() (uint32, error) {
+	conn.Lock()
+	defer conn.Unlock()
 	return conn.initialWindowSize, nil
 }
 


### PR DESCRIPTION
Discovered with the go race detector. It races with processFrame() around line 1121.
