### PR TITLE
Handle empty URL path

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ func TestClient(t *testing.T) {
 
 	client := newClient()
 
-	r, err := client.Get(ts.URL + "/")
+	r, err := client.Get(ts.URL)
 	var b []byte
 	if err == nil {
 		b, err = pedanticReadAll(r.Body)
@@ -42,7 +42,7 @@ func TestClientHead(t *testing.T) {
 	defer ts.Close()
 
 	client := newClient()
-	r, err := client.Head(ts.URL + "/")
+	r, err := client.Head(ts.URL)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Section "3.2.1 Request" of the 3.1 spec indicates:

":path" - the url-path for this url with "/" prefixed. (See RFC3986).  For example, for "http://www.google.com/search?q=dogs" the path would be "/search?q=dogs".

RFC3986 3.3 explicitly permits an empty path.

I believe the correct interpretation of these two requirements is that
any path that does not begin with "/", including an empty path, should
have "/" prefixed for the :path field.

This causes client.Get("http://www.example.com") to behave as the caller
likely expects (returning the equivalent of "GET /").

The v2 spec is slightly less explicit about this (it just says "absolute path"), but I believe it makes sense to interpret that in light of the v3 changes and still prefix the "/" if it's missing.

(This builds on 2ddc5c8 by removing the `+"/"` hack I had put in there.)
