### PR TITLE
Encode full RequestURI (not just the path) in RequestURI field

### DIFF
--- a/spdy2_conn.go
+++ b/spdy2_conn.go
@@ -628,7 +628,7 @@ func (conn *connV2) handlePush(frame *synStreamFrameV2) {
 		RemoteAddr: conn.remoteAddr,
 		Header:     header,
 		Host:       url.Host,
-		RequestURI: url.Path,
+		RequestURI: url.RequestURI(),
 		TLS:        conn.tlsState,
 	}
 
@@ -922,7 +922,7 @@ func (conn *connV2) newStream(frame *synStreamFrameV2, priority Priority) *serve
 		RemoteAddr: conn.remoteAddr,
 		Header:     header,
 		Host:       url.Host,
-		RequestURI: url.Path,
+		RequestURI: url.RequestURI(),
 		TLS:        conn.tlsState,
 		Body:       &readCloser{stream.requestBody},
 	}

--- a/spdy3_conn.go
+++ b/spdy3_conn.go
@@ -644,7 +644,7 @@ func (conn *connV3) handlePush(frame *synStreamFrameV3) {
 		RemoteAddr: conn.remoteAddr,
 		Header:     header,
 		Host:       url.Host,
-		RequestURI: url.Path,
+		RequestURI: url.RequestURI(),
 		TLS:        conn.tlsState,
 	}
 
@@ -1001,7 +1001,7 @@ func (conn *connV3) newStream(frame *synStreamFrameV3, priority Priority) *serve
 		RemoteAddr: conn.remoteAddr,
 		Header:     header,
 		Host:       url.Host,
-		RequestURI: url.Path,
+		RequestURI: url.RequestURI(),
 		TLS:        conn.tlsState,
 		Body:       &readCloser{stream.requestBody},
 	}


### PR DESCRIPTION
Without this, requests like /test?x=1 become /test.
