### PR TITLE
Respect request.Host override

### DIFF
--- a/spdy2/requests.go
+++ b/spdy2/requests.go
@@ -50,13 +50,18 @@ func (c *Conn) Request(request *http.Request, receiver common.Receiver, priority
 		path = "/" + path
 	}
 
+	host := url.Host
+	if request.Host != "" {
+		host = request.Host
+	}
+
 	syn := new(frames.SYN_STREAM)
 	syn.Priority = priority
 	syn.Header = request.Header
 	syn.Header.Set("method", request.Method)
 	syn.Header.Set("url", path)
 	syn.Header.Set("version", "HTTP/1.1")
-	syn.Header.Set("host", url.Host)
+	syn.Header.Set("host", host)
 	syn.Header.Set("scheme", url.Scheme)
 
 	// Prepare the request body, if any.

--- a/spdy3/requests.go
+++ b/spdy3/requests.go
@@ -49,13 +49,18 @@ func (c *Conn) Request(request *http.Request, receiver common.Receiver, priority
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
+
+	host := url.Host
+	if len(request.Host) > 0 {
+		host = request.Host
+	}
 	syn := new(frames.SYN_STREAM)
 	syn.Priority = priority
 	syn.Header = request.Header
 	syn.Header.Set(":method", request.Method)
 	syn.Header.Set(":path", path)
 	syn.Header.Set(":version", "HTTP/1.1")
-	syn.Header.Set(":host", url.Host)
+	syn.Header.Set(":host", host)
 	syn.Header.Set(":scheme", url.Scheme)
 
 	// Prepare the request body, if any.


### PR DESCRIPTION
The request should use `request.Host` as the host if it is set as per `http.Request` spec
