### PR TITLE
Fixes #78 – resource leak with streams

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/SlyMarbo/spdy"
+	"github.com/SlyMarbo/spdy/common"
 )
 
 func init() {
@@ -37,6 +38,28 @@ func TestClient(t *testing.T) {
 		t.Error(err)
 	} else if s := string(b); !strings.HasPrefix(s, "User-agent:") {
 		t.Errorf("Incorrect page body (did not begin with User-agent): %q", s)
+	}
+}
+
+func TestClientClosesResources(t *testing.T) {
+	defer afterTest(t)
+	ts := newServer(robotsTxtHandler)
+	defer ts.Close()
+
+	client := newClient()
+
+	for i := 0; i < common.DEFAULT_STREAM_LIMIT+1; i++ {
+		r, err := client.Get(ts.URL)
+		var b []byte
+		if err == nil {
+			b, err = pedanticReadAll(r.Body)
+			r.Body.Close()
+		}
+		if err != nil {
+			t.Error(err)
+		} else if s := string(b); !strings.HasPrefix(s, "User-agent:") {
+			t.Errorf("Incorrect page body (did not begin with User-agent): %q", s)
+		}
 	}
 }
 

--- a/spdy2/requests.go
+++ b/spdy2/requests.go
@@ -137,6 +137,9 @@ func (c *Conn) Request(request *http.Request, receiver common.Receiver, priority
 func (c *Conn) RequestResponse(request *http.Request, receiver common.Receiver, priority common.Priority) (*http.Response, error) {
 	res := common.NewResponse(request, receiver)
 
+	// Ensure that we decrement the counter once the request is done
+	defer c.requestStreamLimit.Close()
+
 	// Send the request.
 	stream, err := c.Request(request, res, priority)
 	if err != nil {

--- a/spdy3/requests.go
+++ b/spdy3/requests.go
@@ -135,6 +135,9 @@ func (c *Conn) Request(request *http.Request, receiver common.Receiver, priority
 func (c *Conn) RequestResponse(request *http.Request, receiver common.Receiver, priority common.Priority) (*http.Response, error) {
 	res := common.NewResponse(request, receiver)
 
+	// Ensure that we decrement the counter once the request is done
+	defer c.requestStreamLimit.Close()
+
 	// Send the request.
 	stream, err := c.Request(request, res, priority)
 	if err != nil {


### PR DESCRIPTION
Not sure whether this is the correct fix, but it contains a failing test
which now passes.

Given a server which specifies a finite max number of streams, we see
the problem.

This change ensures that the requestStreamLimit is managed
appropriately.