### PR TITLE
flate failure after ~10k requests

### DIFF
--- a/common/compression.go
+++ b/common/compression.go
@@ -194,14 +194,14 @@ func (c *compressor) Compress(h http.Header) ([]byte, error) {
 			case c.w = <-zlibV2Writers:
 				c.w.Reset(c.buf)
 			default:
-				c.w, err = zlib.NewWriterLevelDict(c.buf, zlib.BestCompression, HeaderDictionaryV2)
+				c.w, err = zlib.NewWriterLevelDict(c.buf, zlib.NoCompression, HeaderDictionaryV2)
 			}
 		case 3:
 			select {
 			case c.w = <-zlibV3Writers:
 				c.w.Reset(c.buf)
 			default:
-				c.w, err = zlib.NewWriterLevelDict(c.buf, zlib.BestCompression, HeaderDictionaryV3)
+				c.w, err = zlib.NewWriterLevelDict(c.buf, zlib.NoCompression, HeaderDictionaryV3)
 			}
 		default:
 			err = versionError


### PR DESCRIPTION
After about 10k requests (streams) on a connection, I get the following failure:

```
(spdy) 2015/04/23 22:36:17 error_handling.go:29: Error: Decompression: flate: corrupt input before offset 97117.
2015/04/23 22:36:17 http: panic serving 127.0.0.1:60039: Could not create request: PROTOCOL_ERROR &{GET https://..konea../ HTTP/1.1 1 1 map[:path:[/] :version:[HTTP/1.1] :host:[localhost:23456] :scheme:[https] User-Agent:[curl/7.37.1] :method:[GET] Accept:[*/*]] 0x63cbe0 0 [] false localhost:23456 map[] map[] <nil> map[] 127.0.0.1:60039 /agents/4143F3BD-70CE-4B12-ACC3-99D3CA3C243C/ <nil>}
goroutine 21674 [running]:
net/http.func·011()
	/usr/local/Cellar/go/1.4.2/libexec/src/net/http/server.go:1130 +0xbb
kace/konea/pkg/koneas.StartRequesterHandler(0x1114148, 0xc2080ddf40, 0xc208034ea0, 0x1113eb0, 0xc2080c5cc0)
	/Users/rnapier/work/agent/src/kace/konea/pkg/koneas/requesterhandler.go:44 +0x44c
kace/konea/pkg/koneas.func·006(0x1114148, 0xc2080ddf40, 0xc208034ea0)
	/Users/rnapier/work/agent/src/kace/konea/pkg/koneas/requesterlistener.go:66 +0x151
net/http.HandlerFunc.ServeHTTP(0xc20802b800, 0x1114148, 0xc2080ddf40, 0xc208034ea0)
	/usr/local/Cellar/go/1.4.2/libexec/src/net/http/server.go:1265 +0x41
net/http.func·012(0x1114148, 0xc2080ddf40, 0xc208034ea0)
	/usr/local/Cellar/go/1.4.2/libexec/src/net/http/server.go:1297 +0xe1
net/http.HandlerFunc.ServeHTTP(0xc2080cd180, 0x1114148, 0xc2080ddf40, 0xc208034ea0)
	/usr/local/Cellar/go/1.4.2/libexec/src/net/http/server.go:1265 +0x41
net/http.(*ServeMux).ServeHTTP(0xc2080c7f50, 0x1114148, 0xc2080ddf40, 0xc208034ea0)
	/usr/local/Cellar/go/1.4.2/libexec/src/net/http/server.go:1541 +0x17d
net/http.serverHandler.ServeHTTP(0xc208081740, 0x1114148, 0xc2080ddf40, 0xc208034ea0)
	/usr/local/Cellar/go/1.4.2/libexec/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2080ddea0)
	/usr/local/Cellar/go/1.4.2/libexec/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
	/usr/local/Cellar/go/1.4.2/libexec/src/net/http/server.go:1751 +0x35e
```

And the client disconnects.

My test case currently creates and closes about 100 streams a second. It fails on the order of 10k-20k attempts, but not a specific reliable number (suggesting a race, but I don't see any problems in the race detector on both the client and server sides).

At least two runs have failed at exactly the same byte in the buffer (97117). Another failed at 97116, another at 97119. So all in a very tight range.

We've also seen:

```
(spdy) 2015/04/23 22:36:08 error_handling.go:29: Error: Decompression: Error: Incorrect header name length..
```

Here is a reproducible case:

server.go

```
// openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes -batch

package main

import (
	"log"
	"net/http"

	"github.com/SlyMarbo/spdy"
)

func httpHandler(w http.ResponseWriter, req *http.Request) {
	http.NotFound(w, req)
}

func main() {
	// spdy.EnableDebugOutput()
	http.HandleFunc("/", httpHandler)
	log.Printf("About to listen on 10443. Go to https://127.0.0.1:10443/")
	err := spdy.ListenAndServeTLS(":10443", "cert.pem", "key.pem", nil)
	if err != nil {
		log.Fatal(err)
	}
}
```

client.go

```
package main

import (
	"io/ioutil"

	"github.com/SlyMarbo/spdy" // This adds SPDY support to net/http
)

func main() {
	// spdy.EnableDebugOutput()
	client := spdy.NewClient(true)

	n := 0
	for {
		n++
		println(n)

		res, err := client.Get("https://localhost:10443/")
		if err != nil {
			panic(err)
		}

		_, err = ioutil.ReadAll(res.Body)
		if err != nil {
			panic(err)
		}
		res.Body.Close()
	}
}
```