### PR TITLE
Spdy2: Fix infinite loop when write data of big size

### DIFF
--- a/spdy2/response_stream.go
+++ b/spdy2/response_stream.go
@@ -103,7 +103,8 @@ func (s *ResponseStream) Write(inputData []byte) (int, error) {
 		dataFrame.StreamID = s.streamID
 		dataFrame.Data = data[:common.MAX_DATA_SIZE]
 		s.output <- dataFrame
-
+		
+		data = data[common.MAX_DATA_SIZE:]
 		written += common.MAX_DATA_SIZE
 	}
 


### PR DESCRIPTION
The Write() of ResponseStream does not chunk the response correctly, and cause infinite loop when data size is greater than common.MAX_DATA_SIZE
